### PR TITLE
117 fix jwt 관련 수정

### DIFF
--- a/src/main/java/com/gongkademy/global/security/filter/JWTCheckFilter.java
+++ b/src/main/java/com/gongkademy/global/security/filter/JWTCheckFilter.java
@@ -59,7 +59,7 @@ public class JWTCheckFilter extends OncePerRequestFilter {
         log.info("JWTCheckFilter doFilterInternal 메소드 ===================");
 
         //accessToken 처리
-        String accessToken = jwtUtil.extractToken(request).toString();
+        String accessToken = jwtUtil.extractToken(request).get();
 
             //access 토큰검증
             if (jwtUtil.isTokenValid(accessToken)) {

--- a/src/main/java/com/gongkademy/global/security/util/JWTUtil.java
+++ b/src/main/java/com/gongkademy/global/security/util/JWTUtil.java
@@ -32,7 +32,7 @@ public class JWTUtil {
     private static final String PK_CLAIM = "pk";
     private static final String BEARER = "Bearer ";
 
-    private static RedisUtil redisUtil;
+    private final RedisUtil redisUtil;
 
     @Value("${JWT_KEY}")
     public void setJwtKey(String jwtKey) {
@@ -73,14 +73,12 @@ public class JWTUtil {
             throw new RuntimeException(e.getMessage());
         }
 
-        String refreshToken = Jwts.builder()
+        return Jwts.builder()
                 .setIssuedAt(now)
                 .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION_PERIOD))
                 .claim(PK_CLAIM, id)
                 .signWith(key)
                 .compact();
-
-        return refreshToken;
     }
 
     /**
@@ -119,11 +117,11 @@ public class JWTUtil {
                 .map(refreshToken -> refreshToken.replace(BEARER, ""));
     }
 
-    public Optional<Long> extractMemberId(String accessToken) {
+    public Optional<Integer> extractMemberId(String accessToken) {
         SecretKey key = null;
         try {
             key = Keys.hmacShaKeyFor(JWT_KEY.getBytes("UTF-8"));
-            return Optional.ofNullable((Long) Jwts.parserBuilder()
+            return Optional.ofNullable((Integer) Jwts.parserBuilder()
                     .setSigningKey(key)
                     .build()
                     .parseClaimsJws(accessToken)


### PR DESCRIPTION
### #️⃣연관된 이슈
- #117 

### 📝상세 내용
-  JWTCheckFilter 에서 Optional 로 받아오던 accesToken을 정상적인 String 형식으로 받아오게 수정
-  JWTUtil 의 createRefreshToken메서드의 refreshToken 인라인화
-  JWTUtil 의 extractMemberId() 추출하는 메소드를 반환값 Optional<> Long 타입에서 Integer 타입으로 변경
-  JWTUtil 의 RedisUtil 필드주입에서 static 삭제, final 추가해서 생성자가 자동으로 생성되도록 수정