### PR TITLE
[Fix] Member 관련 코드 수정

### DIFF
--- a/src/main/java/com/gongkademy/domain/member/entity/Member.java
+++ b/src/main/java/com/gongkademy/domain/member/entity/Member.java
@@ -39,9 +39,7 @@ public class Member {
     private String name;
     @NotEmpty
     private String email;
-    @NotEmpty
     private String nickname;
-    @NotEmpty
     private LocalDate birthday;
 
     private String university;

--- a/src/main/java/com/gongkademy/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/gongkademy/domain/member/repository/MemberRepository.java
@@ -1,10 +1,16 @@
 package com.gongkademy.domain.member.repository;
 
 import com.gongkademy.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    @EntityGraph(attributePaths = {"memberRoleList"})
     Optional<Member> findByEmail(String email);
+
+    @Override
+    @EntityGraph(attributePaths = {"memberRoleList"})
+    Optional<Member> findById(Long id);
 }

--- a/src/main/java/com/gongkademy/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/gongkademy/domain/member/service/MemberServiceImpl.java
@@ -72,7 +72,6 @@ public class MemberServiceImpl implements MemberService{
         if (optMember.isEmpty()) return null;
 
         Member member = optMember.get();
-        member.addRole(MemberRole.USER);
         member.update(memberUpdateDTO);
 
         return member.getId();


### PR DESCRIPTION
### #️⃣연관된 이슈
- #118 

### 📝상세 내용
- Member Entity의 nickname, birthday의 NotEmpty 어노테이션 삭제
    - 소셜 로그인 후 Member 객체 생성 시 email과 name 만 처음에 존재하기 때문에 그 두 개의 필드만 NotEmpty 어노테이션을 남겨놓음
- MemberRepository 의 findby~~ 메소드에 EntityGraph(attributePaths = {"memberRoleList"}) 추가 (list 타입의 memberRoler 에서 지연로딩 문제 해결)
    - 그러나 사용이 잦은 메서드에 EntityGraph 어노테이션을 설정하는 것이 적절한가에 대한 의문은 아직 해결하지 못함
    - 빠른 시일 내에 확정하도록 하겠음 !
- memberRepositoryImpl 의 modifyMember에 addRole 메서드 삭제 (중복로직)
    - 회원 수정 시 MemberRole.USER 가 중복으로 추가되는 것을 수정

