### PR TITLE
129 feat notification 관련 로직 구현

### DIFF
--- a/src/main/java/com/gongkademy/domain/notification/dto/NotificationDTO.java
+++ b/src/main/java/com/gongkademy/domain/notification/dto/NotificationDTO.java
@@ -1,4 +1,26 @@
 package com.gongkademy.domain.notification.dto;
 
+import com.gongkademy.domain.notification.entity.NotificationType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class NotificationDTO {
+
+    //알람 목록조회
+    private String receiver;
+    private NotificationType type;
+    private Long articleId;
+    private String message;
+    private boolean isRead;
+    private LocalDateTime create_date;
+
+
 }

--- a/src/main/java/com/gongkademy/domain/notification/dto/request/NotificationRequestDTO.java
+++ b/src/main/java/com/gongkademy/domain/notification/dto/request/NotificationRequestDTO.java
@@ -1,0 +1,24 @@
+package com.gongkademy.domain.notification.dto.request;
+
+import com.gongkademy.domain.member.entity.Member;
+import com.gongkademy.domain.notification.entity.NotificationType;
+import jakarta.persistence.Column;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class NotificationRequestDTO {
+
+    //알림 전송
+    private long receiver;
+    private NotificationType type;
+    private long articleId;
+    private String message;
+}

--- a/src/main/java/com/gongkademy/domain/notification/dto/response/NotificationResponseDTO.java
+++ b/src/main/java/com/gongkademy/domain/notification/dto/response/NotificationResponseDTO.java
@@ -1,4 +1,4 @@
-package com.gongkademy.domain.notification.dto;
+package com.gongkademy.domain.notification.dto.response;
 
 import com.gongkademy.domain.notification.entity.NotificationType;
 import lombok.AllArgsConstructor;
@@ -12,15 +12,15 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class NotificationDTO {
+public class NotificationResponseDTO {
 
     //알람 목록조회
-    private String receiver;
+    private long receiver;
     private NotificationType type;
-    private Long articleId;
+    private long articleId;
     private String message;
     private boolean isRead;
-    private LocalDateTime create_date;
+    private LocalDateTime createDate;
 
 
 }

--- a/src/main/java/com/gongkademy/domain/notification/entity/Notification.java
+++ b/src/main/java/com/gongkademy/domain/notification/entity/Notification.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
@@ -18,6 +20,7 @@ import java.util.List;
 @Getter
 @Setter
 @NoArgsConstructor
+@SuperBuilder
 public class Notification {
 
     @Id
@@ -30,6 +33,7 @@ public class Notification {
     private Member receiver;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private NotificationType type;
 
     @Column(nullable = false)
@@ -39,10 +43,12 @@ public class Notification {
     private String message;
 
     @Column(nullable = false)
-    private boolean isRead;
+    @Builder.Default
+    private boolean isRead = false;
 
     @Column(nullable = false)
-    private LocalDateTime createDate;
+    @Builder.Default
+    private LocalDateTime createDate = LocalDateTime.now();
 
 
 

--- a/src/main/java/com/gongkademy/domain/notification/entity/Notification.java
+++ b/src/main/java/com/gongkademy/domain/notification/entity/Notification.java
@@ -1,11 +1,23 @@
 package com.gongkademy.domain.notification.entity;
 
 import com.gongkademy.domain.member.entity.Member;
+import com.gongkademy.domain.member.entity.MemberRole;
 import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
+@Getter
+@Setter
+@NoArgsConstructor
 public class Notification {
 
     @Id
@@ -14,16 +26,22 @@ public class Notification {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Member receiver;
 
-    private String type;
+    @Column(nullable = false)
+    private NotificationType type;
 
+    @Column(nullable = false)
     private Long articleId;
 
+    @Column(nullable = false)
     private String message;
 
+    @Column(nullable = false)
     private boolean isRead;
 
+    @Column(nullable = false)
     private LocalDateTime createDate;
 
 

--- a/src/main/java/com/gongkademy/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/gongkademy/domain/notification/entity/NotificationType.java
@@ -1,0 +1,13 @@
+package com.gongkademy.domain.notification.entity;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationType {
+    Board("Board"),Notice("Notice");
+
+    private final String key;
+}

--- a/src/main/java/com/gongkademy/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/gongkademy/domain/notification/entity/NotificationType.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum NotificationType {
-    Board("Board"),Notice("Notice");
+    CONSULTING("consulting"), QUESTION("question"), NOTICE("notice");
 
     private final String key;
 }

--- a/src/main/java/com/gongkademy/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/gongkademy/domain/notification/repository/NotificationRepository.java
@@ -3,5 +3,12 @@ package com.gongkademy.domain.notification.repository;
 import com.gongkademy.domain.notification.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
-}
+        List<Notification> findByreceiverAndCreateDate(Long memberId, LocalDateTime now);
+    }
+
+

--- a/src/main/java/com/gongkademy/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/gongkademy/domain/notification/repository/NotificationRepository.java
@@ -1,4 +1,7 @@
 package com.gongkademy.domain.notification.repository;
 
-public interface NotificationRepository {
+import com.gongkademy.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
 }

--- a/src/main/java/com/gongkademy/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/gongkademy/domain/notification/service/NotificationService.java
@@ -1,7 +1,15 @@
 package com.gongkademy.domain.notification.service;
 
+import com.gongkademy.domain.notification.entity.Notification;
+import com.gongkademy.domain.notification.entity.NotificationType;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
-public class NotificationService {
+public interface NotificationService {
+
+    Notification createNotification(Long memberId, NotificationType type, Long articleId, String message);
+    List<Notification> getNotifications(Long memberId);
+    void isRead(Long notificationId);
 }


### PR DESCRIPTION
### #️⃣연관된 이슈
-  #129 

### 📝상세 내용
-  Notification entity 수정
- Notification 내 type enum으로 변경
- NotificationDto -> NotificationResponseDTO 와 NotificationRequestDTO
- NotificationRepository 에 JpaRepository 로직 & 메서드 추가
- NotificationService 메서드 구조 작성

