### PR TITLE
Fix: Proxy -> Object 형 변환 문제 해결

### DIFF
--- a/src/main/java/com/gongkademy/domain/community/controller/ConsultingController.java
+++ b/src/main/java/com/gongkademy/domain/community/controller/ConsultingController.java
@@ -36,9 +36,9 @@ public class ConsultingController {
     }
 
     // Consulting 상세 조회
-    @GetMapping("/{articleNo}")
-    public ResponseEntity<?> getConsulting(@PathVariable Long articleNo) {
-        BoardResponseDTO result = consultingBoardService.findConsultingBoard(articleNo);
+    @GetMapping("/{articleId}")
+    public ResponseEntity<?> getConsulting(@PathVariable Long articleId) {
+        BoardResponseDTO result = consultingBoardService.findConsultingBoard(articleId);
         return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 
@@ -50,9 +50,9 @@ public class ConsultingController {
     }
 
     // Consulting 수정
-    @PatchMapping("/{articleNo}")
-    public ResponseEntity<?> updateConsulting(@PathVariable Long articleNo, @RequestBody BoardRequestDTO consultingBoardRequestDTO) {
-        Long updatedArticleNo = consultingBoardService.updateConsultingBoard(articleNo, consultingBoardRequestDTO);
+    @PatchMapping("/{articleId}")
+    public ResponseEntity<?> updateConsulting(@PathVariable Long articleId, @RequestBody BoardRequestDTO consultingBoardRequestDTO) {
+        Long updatedArticleNo = consultingBoardService.updateConsultingBoard(articleId, consultingBoardRequestDTO);
 
         // 해당 Consulting 게시글이 없는 경우
         if (updatedArticleNo == null) {
@@ -63,9 +63,9 @@ public class ConsultingController {
     }
 
     // Consulting 삭제
-    @DeleteMapping("/{articleNo}")
-    public ResponseEntity<?> deleteConsulting(@PathVariable Long articleNo) {
-        consultingBoardService.deleteConsultingBoard(articleNo);
+    @DeleteMapping("/{articleId}")
+    public ResponseEntity<?> deleteConsulting(@PathVariable Long articleId) {
+        consultingBoardService.deleteConsultingBoard(articleId);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 

--- a/src/main/java/com/gongkademy/domain/community/controller/QuestionController.java
+++ b/src/main/java/com/gongkademy/domain/community/controller/QuestionController.java
@@ -35,9 +35,9 @@ public class QuestionController {
     }
 
     // Qna 상세 조회
-    @GetMapping("/{articleNo}")
-    public ResponseEntity<?> getQna(@PathVariable Long articleNo) {
-        QnaBoardResponseDTO result = qnaboardService.findQnaBoard(articleNo);
+    @GetMapping("/{articleId}")
+    public ResponseEntity<?> getQna(@PathVariable Long articleId) {
+        QnaBoardResponseDTO result = qnaboardService.findQnaBoard(articleId);
         return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 
@@ -49,9 +49,9 @@ public class QuestionController {
     }
 
     // Qna 수정
-    @PatchMapping("/{articleNo}")
-    public ResponseEntity<?> updateQna(@PathVariable Long articleNo, @RequestBody QnaBoardRequestDTO qnaBoardRequestDTO) {
-        Long updateArticleNo = qnaboardService.updateQnaBoard(articleNo, qnaBoardRequestDTO);
+    @PatchMapping("/{articleId}")
+    public ResponseEntity<?> updateQna(@PathVariable Long articleId, @RequestBody QnaBoardRequestDTO qnaBoardRequestDTO) {
+        Long updateArticleNo = qnaboardService.updateQnaBoard(articleId, qnaBoardRequestDTO);
 
         // 해당 Qna 게시글이 없는 경우
         if (updateArticleNo == null) {
@@ -62,9 +62,9 @@ public class QuestionController {
     }
 
     // Qna 삭제
-    @DeleteMapping("/{articleNo}")
-    public ResponseEntity<?> deleteQna(@PathVariable Long articleNo) {
-        qnaboardService.deleteQnaBoard(articleNo);
+    @DeleteMapping("/{articleId}")
+    public ResponseEntity<?> deleteQna(@PathVariable Long articleId) {
+        qnaboardService.deleteQnaBoard(articleId);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 

--- a/src/main/java/com/gongkademy/domain/community/service/ConsultingBoardServiceImpl.java
+++ b/src/main/java/com/gongkademy/domain/community/service/ConsultingBoardServiceImpl.java
@@ -4,6 +4,7 @@ package com.gongkademy.domain.community.service;
 import com.gongkademy.domain.community.dto.request.BoardRequestDTO;
 import com.gongkademy.domain.community.dto.response.BoardResponseDTO;
 import com.gongkademy.domain.community.entity.board.Board;
+import com.gongkademy.domain.community.entity.board.QnaBoard;
 import com.gongkademy.domain.community.entity.pick.Pick;
 import com.gongkademy.domain.community.entity.pick.PickType;
 import com.gongkademy.domain.community.repository.BoardRepository;
@@ -143,7 +144,8 @@ public class ConsultingBoardServiceImpl implements ConsultingBoardService{
         List<BoardResponseDTO> likeBoardDTOs = new ArrayList<>();
 
         for (Pick like : likes) {
-            likeBoardDTOs.add(convertToDTO(like.getBoard()));
+            Optional<Board> consultingBoard = boardRepository.findById(like.getBoard().getArticleId());
+            consultingBoard.ifPresent(board -> likeBoardDTOs.add(convertToDTO(board)));
         }
 
         return likeBoardDTOs;
@@ -158,7 +160,8 @@ public class ConsultingBoardServiceImpl implements ConsultingBoardService{
         List<BoardResponseDTO> scrapBoardDTOs = new ArrayList<>();
 
         for (Pick like : likes) {
-            scrapBoardDTOs.add(convertToDTO(like.getBoard()));
+            Optional<Board> consultingBoard = boardRepository.findById(like.getBoard().getArticleId());
+            consultingBoard.ifPresent(board -> scrapBoardDTOs.add(convertToDTO(board)));
         }
 
         return scrapBoardDTOs;

--- a/src/main/java/com/gongkademy/domain/community/service/QnaBoardServiceImpl.java
+++ b/src/main/java/com/gongkademy/domain/community/service/QnaBoardServiceImpl.java
@@ -145,7 +145,8 @@ public class QnaBoardServiceImpl implements QnaBoardService {
         List<QnaBoardResponseDTO> likeBoardDTOs = new ArrayList<>();
 
         for (Pick like : likes) {
-            likeBoardDTOs.add(convertToDTO((QnaBoard) like.getBoard()));
+            Optional<QnaBoard> qnaBoard = qnaBoardRepository.findById(like.getBoard().getArticleId());
+            qnaBoard.ifPresent(board -> likeBoardDTOs.add(convertToDTO(board)));
         }
 
         return likeBoardDTOs;
@@ -161,7 +162,9 @@ public class QnaBoardServiceImpl implements QnaBoardService {
         List<QnaBoardResponseDTO> scrapBoardDTOs = new ArrayList<>();
 
         for (Pick like : likes) {
-            scrapBoardDTOs.add(convertToDTO((QnaBoard) like.getBoard()));
+            Optional<QnaBoard> qnaBoard = qnaBoardRepository.findById(like.getBoard().getArticleId());
+            qnaBoard.ifPresent(board -> scrapBoardDTOs.add(convertToDTO(board)));
+            ;
         }
 
         return scrapBoardDTOs;


### PR DESCRIPTION
### #️⃣연관된 이슈
- resolve #134 

### 📝상세 내용
- 좋아요한 게시글 혹은 스크랩한 게시글을 불러오는 과정에서 Fetch.Lazy 설정을 하여 Entity를 가져오는 것이 아닌 Proxy 형태의 객체를 반환하고 있던 상태였음.
- 그에 따라 Board 혹은 QnaBoard를 Dto로 변환하는 과정에서 Entity(실제 객체)를 활용해야 하는데 Proxy 객체를 활용하여 메서드가 제대로 동작하지 않음.
- 이를 해결하기 위해 Proxy 객체가 가지고 있는 PK 값을 이용해 Repository에서 Entity(실제 객체)를 가져오도록 바꿔서 코드를 작성하였음
- 해당 링크를 통해 내용을 확인 
https://velog.io/@ky0_hw/JPA-OneToMany-%EA%B4%80%EA%B3%84%EC%97%90%EC%84%9C%EC%9D%98-Lazy%EC%99%80-%ED%94%84%EB%A1%9D%EC%8B%9C-%EB%AC%B8%EC%A0%9C-%ED%95%B4%EA%B2%B0

