### PR TITLE
Feat: 151 commentcontroller 에 알림 전송 기능 구현

### DIFF
--- a/src/main/java/com/gongkademy/domain/community/controller/CommentController.java
+++ b/src/main/java/com/gongkademy/domain/community/controller/CommentController.java
@@ -2,15 +2,19 @@ package com.gongkademy.domain.community.controller;
 
 import com.gongkademy.domain.community.dto.request.CommentRequestDTO;
 import com.gongkademy.domain.community.dto.response.CommentResponseDTO;
+import com.gongkademy.domain.community.entity.board.BoardType;
+import com.gongkademy.domain.community.repository.BoardRepository;
 import com.gongkademy.domain.community.service.CommentService;
 import com.gongkademy.domain.member.dto.PrincipalDetails;
+import com.gongkademy.domain.member.repository.MemberRepository;
+import com.gongkademy.domain.notification.dto.request.NotificationRequestDTO;
+import com.gongkademy.domain.notification.entity.NotificationType;
+import com.gongkademy.domain.notification.service.NotificationServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/community")
@@ -18,10 +22,31 @@ import java.util.List;
 public class CommentController {
 
     private final CommentService commentService;
+    private final NotificationServiceImpl notificationService;
+    private final MemberRepository memberRepository;
+    private final BoardRepository boardRepository;
 
     @PostMapping
     public ResponseEntity<?> createComment(@RequestBody CommentRequestDTO commentRequestDTO) {
         CommentResponseDTO commentResponseDTO = commentService.createComment(commentRequestDTO);
+
+        long articleId = commentRequestDTO.getArticleId();
+        BoardType boardType = boardRepository.findBoardTypeByBoardId(articleId);
+        //게시글 주인 아이디 찾기
+        long articleOwnerId = boardRepository.findMemberIdByBoardId(articleId);
+
+        //Todo : 이렇게하면 일단 대댓글의 주인한테는 알림이 안가고 게시글의 주인한테만 감
+        // 대댓글은 필요 시 다시 작업
+        NotificationRequestDTO notificationRequestDTO = NotificationRequestDTO.builder()
+                .receiver(articleOwnerId)
+                .type(mapToNotificationType(boardType))
+                .articleId(commentRequestDTO.getArticleId())
+                .message(commentRequestDTO.getContent())
+                .build();
+
+        //Todo: 알림 전송 기능
+        notificationService.createNotification(notificationRequestDTO);
+
         return new ResponseEntity<>(commentResponseDTO, HttpStatus.CREATED);
     }
 
@@ -49,5 +74,18 @@ public class CommentController {
         Long currentMemberId = principalDetails.getMemberId();
         commentService.toggleLikeComment(commentId, currentMemberId);
         return ResponseEntity.ok().build();
+    }
+
+    private NotificationType mapToNotificationType(BoardType boardType) {
+        switch (boardType) {
+            case NOTICE:
+                return NotificationType.NOTICE;
+            case CONSULT:
+                return NotificationType.CONSULTING;
+            case QNA:
+                return NotificationType.QUESTION;
+            default:
+                throw new IllegalArgumentException("Unsupported board type: " + boardType);
+        }
     }
 }

--- a/src/main/java/com/gongkademy/domain/community/repository/BoardRepository.java
+++ b/src/main/java/com/gongkademy/domain/community/repository/BoardRepository.java
@@ -6,9 +6,12 @@ import com.gongkademy.domain.community.entity.board.QnaBoard;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long> {
@@ -19,5 +22,12 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     // 최신순 조회
     Page<Board> findByOrderByCreateTimeDesc(Pageable pageable);
+
+    @Query("SELECT b.member.id FROM Board b WHERE b.articleId = :boardId")
+    Long findMemberIdByBoardId(@Param("boardId") Long boardId);
+
+    @Query("SELECT b.boardType FROM Board b WHERE b.articleId = :boardId")
+    BoardType findBoardTypeByBoardId(@Param("boardId") Long boardId);
+
 
 }


### PR DESCRIPTION
### #️⃣연관된 이슈
- resolve #151

### 📝상세 내용
- CommentController 에 알림 전송 기능 구현
-  BoardRepository 에 findBoardTypeByBoardId , findMemberIdByBoardId 메소드 추가 구현

---
![image](https://github.com/Gongkademy/Gongkademy_Service_Back/assets/117634128/0e0d1616-5103-4d36-9775-a86587ea2d57)

![image](https://github.com/Gongkademy/Gongkademy_Service_Back/assets/117634128/32a5a6a6-a53f-471f-a613-7c739f07b233)

